### PR TITLE
upgraded to raven 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@financial-times/n-logger": "^5.0.2",
     "fetchres": "^1.5.1",
-    "raven": "^0.10.0"
+    "raven": "^0.12.0"
   },
   "devDependencies": {
     "chai": "^3.3.0",


### PR DESCRIPTION
@adgad I think you contributed most to this apart from me. Can you see any reason in the release notes https://github.com/getsentry/raven-node/releases (0.11 and 0.12) to be wary of doing this.

The main advantage is (probably) better error parsing and addition of user details to the error, which could be massively useful
