### PR TITLE
Update raven

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,69 +2,8 @@
 'use strict';
 
 const logger = require('@financial-times/n-logger').default;
-const fetchres = require('fetchres');
 const raven = require('raven');
 const path = require('path');
-let ravenMiddleware;
-
-function sendErrorDev (err, req, res, next) {
-	let error;
-	if (err instanceof Error) {
-		error = {
-			name: err.name,
-			message: err.message
-		};
-		if (err.stack) {
-			error.stack = err.stack.split('\n');
-		}
-	} else {
-		error = err;
-	}
-	if (err.name === fetchres.ReadTimeoutError.name) {
-		logger.error(err, { event: 'dependencytimeout' });
-		res && res.status(504).send({ type: 'Bad Gateway', error: error });
-	} else {
-		logger.error(err, { event: 'uncaughterror' });
-		res && res.status(500).send({ type: 'Uncaught Error', error: error });
-	}
-}
-
-function sendErrorProd (err, req, res, next) {
-	if (err.name === fetchres.ReadTimeoutError.name) {
-		logger.error(err, { event: 'dependencytimeout' });
-		res && res.status(504).send({ type: 'Bad Gateway', error: err });
-	} else {
-		logger.error(err, { event: 'uncaughterror' });
-		if (req && res && next) {
-			err = sanitiseError(err);
-			return ravenMiddleware(err, req, res, next);
-		}
-	}
-}
-
-function getUpstreamErrorHandler (errorReporter) {
-	return function (res, next, statusCode) {
-		return function (err) {
-
-			if (err.name === fetchres.BadServerResponseError.name) {
-				errorReporter(err);
-				res.status(statusCode).end();
-			} else {
-				next(err);
-			}
-		};
-	};
-}
-
-function getCaptureError (client, _captureError) {
-	return function (err) {
-		if (err.name === fetchres.ReadTimeoutError.name) {
-			logger.error(err, { event: 'dependencytimeout' });
-		} else {
-			_captureError.apply(client, arguments);
-		}
-	};
-}
 
 function sanitiseError (err) {
 	//Initially check for a specific email field e.g. in a url in an attempt to not blitz helpful error information if possible
@@ -114,35 +53,44 @@ if (process.env.NODE_ENV === 'production') {
 		about = {};
 	}
 
-	const client = new raven.Client(process.env.RAVEN_URL, {
-		release: about.appVersion || 'unknown',
-		name: about.description || 'unknown',
-		tags: {
-			buildTime: about.buildCompletionTime || 'unknown'
-		}
-	});
+	raven
+		.config(process.env.RAVEN_URL, {
+			release: about.appVersion || 'unknown',
+			name: about.description || 'unknown',
+			tags: {
+				buildTime: about.buildCompletionTime || 'unknown'
+			}
+		})
+		// Die on uncaughtException
+		// https://docs.sentry.io/clients/node/usage/#global-fatal-error-handler
+		.install(() => process.exit(1));
 
-	const _captureError = client.captureError;
-	module.exports = client;
-	module.exports.captureError = getCaptureError(client, _captureError);
+	module.exports = raven;
 	module.exports.middleware = sendErrorProd;
-	module.exports.upstreamErrorHandler = getUpstreamErrorHandler(sendErrorProd);
-
-	ravenMiddleware = raven.middleware.express(client);
-
-	// Die on uncaughtException
-	// https://github.com/getsentry/raven-node#catching-global-errors
-	client.patchGlobal(function () {
-		process.exit(1);
-	});
 
 } else {
 
 	module.exports = {
+		context: func => func(),
 		captureMessage: logger.warn.bind(logger),
 		captureError: logger.error.bind(logger),
-		middleware: sendErrorDev,
-		upstreamErrorHandler: getUpstreamErrorHandler(sendErrorDev)
+		requestHandler: () => (req, res, next) => next(),
+		errorHandler: () => (err, req, res, next) => {
+			let error;
+			if (err instanceof Error) {
+				error = {
+					name: err.name,
+					message: err.message
+				};
+				if (err.stack) {
+					error.stack = err.stack.split('\n');
+				}
+			} else {
+				error = err;
+			}
+			logger.error(err, { event: 'uncaughterror' });
+			res && res.status(500).send({ type: 'Uncaught Error', error: error });
+		}
 	};
 }
 

--- a/main.js
+++ b/main.js
@@ -66,7 +66,18 @@ if (process.env.NODE_ENV === 'production') {
 		.install(() => process.exit(1));
 
 	module.exports = raven;
-	module.exports.middleware = sendErrorProd;
+
+	const _errorHandler = raven.errorHandler;
+	module.exports.errorHandler = () => {
+		const middleware = _errorHandler();
+		return (err, req, res, next) => {
+			logger.error(err, { event: 'uncaughterror' });
+			if (req && res && next) {
+				err = sanitiseError(err);
+				return middleware(err, req, res, next);
+			}
+		};
+	};
 
 } else {
 

--- a/main.js
+++ b/main.js
@@ -67,8 +67,8 @@ if (process.env.NODE_ENV === 'production') {
 
 	module.exports = raven;
 
-	const _errorHandler = raven.errorHandler;
-	module.exports.errorHandler = () => {
+	const _errorHandler = raven.errorHandler.bind(raven);
+	module.exports.errorHandler = function () {
 		const middleware = _errorHandler();
 		return (err, req, res, next) => {
 			logger.error(err, { event: 'uncaughterror' });

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@financial-times/n-logger": "^5.0.2",
-    "fetchres": "^1.5.1",
-    "raven": "^0.12.0"
+    "raven": "^2.0.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.8.21",

--- a/test/dev.spec.js
+++ b/test/dev.spec.js
@@ -3,37 +3,22 @@
 const expect = require('chai').expect;
 const request = require('supertest');
 const express = require('express');
-const fetchres = require('fetchres');
-const errorsHandler = require('../main');
+const nRaven = require('../main');
 const logger = require('@financial-times/n-logger').default;
 const sinon = require('sinon');
 
 describe('express errors handler in dev', function () {
 	let app;
-	const readTimeoutError = new fetchres.ReadTimeoutError();
-	const badServerError = new fetchres.BadServerResponseError(418);
 
 	const error = new Error('potato');
 	before(function () {
 		app = express();
-
+		app.use(nRaven.requestHandler());
 		app.get('/caught-error', function (req, res, next) {
 			next(error);
 		});
 
-		app.get('/timeout', function (req, res, next) {
-			next(readTimeoutError);
-		});
-
-		app.get('/bad-response', function (req, res) {
-			errorsHandler.upstreamErrorHandler(res, req, 513)(badServerError);
-		});
-
-		app.get('/not-bad-response', function (req, res) {
-			errorsHandler.upstreamErrorHandler(res, req, 513)(error);
-		});
-
-		app.use(errorsHandler.middleware);
+		app.use(nRaven.errorHandler());
 	});
 
 	beforeEach(() => sinon.stub(logger, 'error'));
@@ -54,43 +39,4 @@ describe('express errors handler in dev', function () {
 				expect(logger.error.calledWith(error, { event: 'uncaughterror' })).to.be.true;
 			});
 	});
-
-	it('handle backend timeout', () => {
-		return request(app)
-			.get('/timeout')
-			.expect(504)
-			.expect(res => {
-				const body = res.body;
-				expect(body).to.have.property('type', 'Bad Gateway');
-				expect(body).to.contain.keys('error');
-				expect(body.error).to.have.property('name', 'ReadTimeoutError');
-				expect(logger.error.calledWith(readTimeoutError, { event: 'dependencytimeout' })).to.be.true;
-			});
-	});
-
-	it('handle backend error with custom response', () => {
-		return request(app)
-			.get('/bad-response')
-			.expect(513)
-			.expect(() => {
-				expect(logger.error.calledWith(badServerError, { event: 'uncaughterror' })).to.be.true;
-			});
-	});
-
-	it('handle non-matching error with default response', () => {
-		return request(app)
-			.get('/not-bad-response')
-			.expect(500)
-			.expect(res => {
-				const body = res.body;
-				expect(body).to.have.property('type', 'Uncaught Error');
-				expect(body).to.contain.keys('error');
-				expect(body.error).to.have.property('name', 'TypeError');
-				expect(body.error).to.have.property('message', 'next is not a function');
-				expect(body.error).to.contain.keys('stack');
-				expect(body.error.stack[0]).to.equal('TypeError: next is not a function');
-				expect(logger.error.calledWith(error, { event: 'uncaughterror' })).to.be.true;
-			});
-	});
-
 });

--- a/test/prod.spec.js
+++ b/test/prod.spec.js
@@ -2,7 +2,6 @@
 const expect = require('chai').expect;
 const request = require('supertest');
 const express = require('express');
-const fetchres = require('fetchres');
 
 const logger = require('@financial-times/n-logger').default;
 const sinon = require('sinon');
@@ -10,44 +9,28 @@ const raven = require('raven');
 
 describe('express errors handler in prod', function () {
 	let app;
-	let errorsHandler;
-	const readTimeoutError = new fetchres.ReadTimeoutError();
-	const badServerError = new fetchres.BadServerResponseError(418);
+	let nRaven;
 	const errorToPassThrough = new Error('potato');
 	const ravenSpy = sinon.spy(function (err, req, res, next) {
 		next(err, req, res);
 	});
-	const captureErrorSpy = sinon.spy();
 	const captureMessageSpy = sinon.spy();
 
 	before(function () {
-		sinon.stub(raven.middleware, 'express', () => ravenSpy);
+		sinon.stub(raven, 'errorHandler', () => ravenSpy);
 
-		const clientStub = function () {};
-		clientStub.prototype.captureMessage = captureMessageSpy;
-		clientStub.prototype.captureError = captureErrorSpy;
-		clientStub.prototype.patchGlobal = sinon.spy();
+		sinon.stub(raven, 'captureMessage', captureMessageSpy);
+		sinon.stub(raven, 'install', sinon.spy());
 
-		sinon.stub(raven, 'Client', clientStub);
-		errorsHandler = require('../main');
+		// sinon.stub(raven, 'Client', clientStub);
+		nRaven = require('../main');
 		app = express();
-
+		app.use(nRaven.requestHandler());
 		app.get('/caught-error', function (req, res, next) {
 			next(errorToPassThrough);
 		});
 
-		app.get('/timeout', function (req, res, next) {
-			next(readTimeoutError);
-		});
-
-		app.get('/bad-response', function (req, res, next) {
-			errorsHandler.upstreamErrorHandler(res, next, 513)(badServerError);
-		});
-
-		app.get('/not-bad-response', function (req, res, next) {
-			errorsHandler.upstreamErrorHandler(res, next, 513)(errorToPassThrough);
-		});
-		app.use(errorsHandler.middleware);
+		app.use(nRaven.errorHandler());
 	});
 
 
@@ -70,52 +53,8 @@ describe('express errors handler in prod', function () {
 			});
 	});
 
-	it('handle backend timeout', function (done) {
-		request(app)
-			.get('/timeout')
-			.end((err, res) => {
-				expect(res.status).to.equal(504);
-				expect(ravenSpy.called).to.be.false;
-				expect(logger.error.calledWith(readTimeoutError, { event: 'dependencytimeout'})).to.be.true;
-				done();
-			});
-	});
-
-	it('handle backend error with custom response', function (done) {
-		request(app)
-			.get('/bad-response')
-			.end((err, res) => {
-				expect(res.status).to.equal(513);
-				expect(ravenSpy.called).to.be.false;
-				expect(logger.error.calledWith(badServerError, { event: 'uncaughterror'})).to.be.true;
-				done();
-			});
-	});
-
-	it('handle non-matching error with default response', function (done) {
-		request(app)
-			.get('/not-bad-response')
-			.end((err, res) => {
-				expect(res.status).to.equal(500);
-				expect(ravenSpy.called).to.be.true;
-				expect(ravenSpy.args[0].length).to.equal(4);
-				expect(logger.error.calledWith(errorToPassThrough, { event: 'uncaughterror'})).to.be.true;
-				done();
-			});
-	});
-
-	it('can capture errors outside of express controllers', function () {
-		errorsHandler.captureError(readTimeoutError);
-		expect(logger.error.calledWith(readTimeoutError, { event: 'dependencytimeout'})).to.be.true;
-
-		errorsHandler.captureError(badServerError);
-		expect(captureErrorSpy.called).to.be.true;
-		expect(captureErrorSpy.args[0].length).to.equal(1);
-		expect(captureErrorSpy.args[0][0].name).to.equal(badServerError.name);
-	});
-
 	it('can capture messages outside of express controllers', function () {
-		errorsHandler.captureMessage('random message');
+		nRaven.captureMessage('random message');
 
 		expect(captureMessageSpy.called).to.be.true;
 		expect(captureMessageSpy.args[0].length).to.equal(1);


### PR DESCRIPTION
We're 2 major versions out of date, and as it communicates with a hosted service we should update.

As well as upgrading, I'm also removing a lot of the complexity around understanding fetchres errors - fetchres isn't universally adopted, so it seems like an unnecessary bit of magic.

I've opened an issue to find out if we still need to do something special to convert to a logger in dev https://forum.sentry.io/t/logging-to-console-in-dev/2472

I'll update the docs as integrating with express is very different in the new raven