### PR TITLE
Bind `captureError` to raven to fix scoping

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ if (process.env.NODE_ENV === 'production') {
 		.install(() => process.exit(1));
 
 	// Support for the legacy captureError function.
-	raven.captureError = raven.captureException;
+	raven.captureError = raven.captureException.bind(raven);
 
 	module.exports = raven;
 


### PR DESCRIPTION
So functions like [`this.generateEventId()`](https://github.com/getsentry/raven-node/blob/f59a264cfbcb52d4ff428ce70dbaa8e11c371316/lib/client.js#L394) can still be accessed.

 🐿 v2.8.0