### PR TITLE
Allow suppressing of error logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
-          version: "7"
+          version: "^7"
       - run:
           name: Install project dependencies
           command: make install

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ app.get('/a-typical-route', async function(req, res, next) {
 app.use(nRaven.errorHandler);
 ```
 
+### Suppressing error logging
+
+By default the raven error handler logs error details as well as sending error information to Sentry. You can suppress this behaviour by setting `response.locals.suppressRavenLogger` to `true` in any route before raven's error handler is registered.
+
 ## Supported environment variables
 - `NODE_ENV` - mode to operate in, can be either `PRODUCTION` (sends bugs to aggregator) or any another value (shows bugs to user)
 - `RAVEN_URL` - URL to report bugs captured in production

--- a/main.js
+++ b/main.js
@@ -74,7 +74,9 @@ if (process.env.NODE_ENV === 'production') {
 	module.exports.errorHandler = function () {
 		const middleware = _errorHandler();
 		return (err, req, res, next) => {
-			logger.error(err, { event: 'uncaughterror' });
+			if (!res.locals.suppressRavenLogger) {
+				logger.error(err, { event: 'uncaughterror' });
+			}
 			if (req && res && next) {
 				err = sanitiseError(err);
 				return middleware(err, req, res, next);
@@ -103,7 +105,9 @@ if (process.env.NODE_ENV === 'production') {
 			} else {
 				error = err;
 			}
-			logger.error(err, { event: 'uncaughterror' });
+			if (!res.locals.suppressRavenLogger) {
+				logger.error(err, { event: 'uncaughterror' });
+			}
 			res && res.status(500).send({ type: 'Uncaught Error', error: error });
 		}
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "supertest": "^3.0.0"
       },
       "engines": {
-        "node": "12.x",
+        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },

--- a/test/dev.spec.js
+++ b/test/dev.spec.js
@@ -17,6 +17,10 @@ describe('express errors handler in dev', function () {
 		app.get('/caught-error', function (req, res, next) {
 			next(error);
 		});
+		app.get('/suppressed-error', function (req, res, next) {
+			res.locals.suppressRavenLogger = true;
+			next(error);
+		});
 
 		app.use(nRaven.errorHandler());
 	});
@@ -37,6 +41,14 @@ describe('express errors handler in dev', function () {
 				expect(body.error).to.contain.keys('stack');
 				expect(body.error.stack[0]).to.equal('Error: potato');
 				expect(logger.error.calledWith(error, { event: 'uncaughterror' })).to.be.true;
+			});
+	});
+
+	it('does not log when errors are suppressed', () => {
+		return request(app)
+			.get('/suppressed-error')
+			.expect(() => {
+				expect(logger.error.notCalled).to.be.true;
 			});
 	});
 });

--- a/test/prod.spec.js
+++ b/test/prod.spec.js
@@ -29,6 +29,10 @@ describe('express errors handler in prod', function () {
 		app.get('/caught-error', function (req, res, next) {
 			next(errorToPassThrough);
 		});
+		app.get('/suppressed-error', function (req, res, next) {
+			res.locals.suppressRavenLogger = true;
+			next(errorToPassThrough);
+		});
 
 		app.use(nRaven.errorHandler());
 	});
@@ -206,6 +210,14 @@ describe('express errors handler in prod', function () {
 					done();
 				});
 		});
+	});
+
+	it('does not log when errors are suppressed', () => {
+		return request(app)
+			.get('/suppressed-error')
+			.expect(() => {
+				expect(logger.error.notCalled).to.be.true;
+			});
 	});
 
 });


### PR DESCRIPTION
We need this in Dotcom Reliability Kit to help ease the transition for
apps which want to start using our logging middleware. Right now if you
register [@dotcom-reliability-kit/middleware-log-errors](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/middleware-log-errors#createerrorlogger) with Express
you will have error information logged twice.

~I'm intending on setting `suppressRavenLogger` in our middleware so that
if an app is using it then Raven logs are automatically suppressed.~
I have set this up in our middleware here as an example of how it is used:
https://github.com/Financial-Times/dotcom-reliability-kit/pull/39

Let me know if you can think of any nicer solutions. I thought it
_could_ be a config option in n-raven but that'd involve us also making
it available to configure in n-express, because that's where most apps
get n-raven from.