### PR TITLE
Fix the codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @financial-times/platforms
-* @financial-times/ft-dotcom
+* @financial-times/platforms @financial-times/ft-dotcom


### PR DESCRIPTION
I messed up, I've always read CODEOWNERS as like a markdown file for
some reason and assumed that asterisk was a bullet point. It's not, it's
a file matcher and the last one takes precedent so I've actually removed
Platforms as codeowners 😂

This is now correct based on the docs:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax