### PR TITLE
Add unhandled error logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const logger = require('@financial-times/n-logger').default;
+const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
 const raven = require('raven');
 const path = require('path');
 
@@ -63,7 +64,10 @@ if (process.env.NODE_ENV === 'production') {
 		})
 		// Die on uncaughtException
 		// https://docs.sentry.io/clients/node/usage/#global-fatal-error-handler
-		.install(() => process.exit(1));
+		.install(error => {
+			logUnhandledError({ error });
+			process.exit(1);
+		});
 
 	// Support for the legacy captureError function.
 	raven.captureError = raven.captureException.bind(raven);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^1.3.0",
         "@financial-times/n-logger": "^10.2.0",
         "raven": "^2.3.0"
       },
@@ -398,6 +399,38 @@
       "resolved": "https://registry.npmjs.org/@deepcode/dcignore/-/dcignore-1.0.2.tgz",
       "integrity": "sha512-DPgxtHuJwBORpqRkPXzzOT+uoPRVJmaN7LR+pmeL6DQM90kj6G6GFUH1i/YpRH8NbML8ZGEDwB9f9u4UwD2pzg==",
       "dev": true
+    },
+    "node_modules/@dotcom-reliability-kit/log-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.3.0.tgz",
+      "integrity": "sha512-3VjGttJoMcurPJO2iL5Cx42xz3PiSSfzXLQjPa0rHqPXKiPdZAsIc3LyJjtUNaU8pav60RUtj1pUpeEy596b6Q==",
+      "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": "^1.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^1.0.0",
+        "@financial-times/n-logger": "^10.2.0"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.0.0.tgz",
+      "integrity": "sha512-ROU7khyWTAIgQf3IzmLwjF5K5CT/pctzxMEr6gG2TmL2L4ahsjxGjq0kt6J8n87lLTAJWy+bu+JpC7c0MJJP1g==",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.0.0.tgz",
+      "integrity": "sha512-1g1LteXQbBQfBZj/bekRIbuREGOKaehXJG3oI7779vYhh7X3f5ohGSjJww1GyPclT9dNkelno4MHDQaJOWngqA==",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
     },
     "node_modules/@financial-times/eslint-config-next": {
       "version": "3.0.0",
@@ -13356,6 +13389,26 @@
       "resolved": "https://registry.npmjs.org/@deepcode/dcignore/-/dcignore-1.0.2.tgz",
       "integrity": "sha512-DPgxtHuJwBORpqRkPXzzOT+uoPRVJmaN7LR+pmeL6DQM90kj6G6GFUH1i/YpRH8NbML8ZGEDwB9f9u4UwD2pzg==",
       "dev": true
+    },
+    "@dotcom-reliability-kit/log-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.3.0.tgz",
+      "integrity": "sha512-3VjGttJoMcurPJO2iL5Cx42xz3PiSSfzXLQjPa0rHqPXKiPdZAsIc3LyJjtUNaU8pav60RUtj1pUpeEy596b6Q==",
+      "requires": {
+        "@dotcom-reliability-kit/serialize-error": "^1.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^1.0.0",
+        "@financial-times/n-logger": "^10.2.0"
+      }
+    },
+    "@dotcom-reliability-kit/serialize-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.0.0.tgz",
+      "integrity": "sha512-ROU7khyWTAIgQf3IzmLwjF5K5CT/pctzxMEr6gG2TmL2L4ahsjxGjq0kt6J8n87lLTAJWy+bu+JpC7c0MJJP1g=="
+    },
+    "@dotcom-reliability-kit/serialize-request": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.0.0.tgz",
+      "integrity": "sha512-1g1LteXQbBQfBZj/bekRIbuREGOKaehXJG3oI7779vYhh7X3f5ohGSjJww1GyPclT9dNkelno4MHDQaJOWngqA=="
     },
     "@financial-times/eslint-config-next": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@dotcom-reliability-kit/log-error": "^1.3.0",
     "@financial-times/n-logger": "^10.2.0",
     "raven": "^2.3.0"
   },


### PR DESCRIPTION
This adds Reliability Kit's error logging to the uncaught exception
handler provided by Sentry. This is not the most ideal place for this
logging, but trust us we tried to do it differently.

Our hope is that we can do this work properly when we have time to
reconsider our use of Sentry and replace it with a module in Reliability
Kit. For more information on why we can't do this yet, see [FTDCS-247](https://financialtimes.atlassian.net/browse/FTDCS-247).

Resolves [FTDCS-253](https://financialtimes.atlassian.net/browse/FTDCS-253).

I tested this locally in Dotcom Debug User by linking my local copy
of n-raven into it. It behaves as expected:

<img width="1070" alt="Screenshot 2022-07-29 at 16 08 44" src="https://user-images.githubusercontent.com/138944/181794180-7eb45100-b3b2-47b1-9698-b3f5e4b18f61.png">

