### PR TITLE
Remove the Platforms team as a Code Owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @financial-times/platforms @financial-times/cp-reliability
+* @financial-times/cp-reliability


### PR DESCRIPTION
We'd like to take this off your hands properly. That OK?